### PR TITLE
Update number of workspaces per user to 2

### DIFF
--- a/charts/devspaces/templates/instance.yaml
+++ b/charts/devspaces/templates/instance.yaml
@@ -12,6 +12,7 @@ spec:
       template: <username>-devspaces
     secondsOfInactivityBeforeIdling: -1
     secondsOfRunBeforeIdling: -1
+    maxNumberOfRunningWorkspacesPerUser: 2
     storage:
       pvcStrategy: per-user
   components:


### PR DESCRIPTION
By default, DevSpaces limits the number of concurrent workspaces per user to 1. 
It would be better to relax to settings to at least max 2.

Link: https://access.redhat.com/documentation/it-it/red_hat_openshift_dev_spaces/3.12/html-single/administration_guide/index#checluster-custom-resource-fields-reference-checluster-custom-resource-status-settings